### PR TITLE
Fix HTML anchor attribute spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
                     Scroll down to find "The Origins Trilogy" or click "learn" at the top<br> 
                     Start with html, then css, then javascript</Strong>
                     </p>
-                    <a href="https://www.codedex.io/" target = "_blank" class="button">Start learning</a>
+                    <a href="https://www.codedex.io/" target="_blank" class="button">Start learning</a>
 
                     </section>
                     <section id="best-practices">


### PR DESCRIPTION
## Summary
- fix spacing in the target attribute on the Codex link

## Testing
- `grep -n "target" -n index.html | head`

------
https://chatgpt.com/codex/tasks/task_e_683f90214e6083278a29c0415459bcc7